### PR TITLE
Rename wrapper to RavyAPI.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plane
+# RavyAPI.py
 
 According to an update from Hazel, the Ravy API will no longer be in operation. The maintenance status of this library is currently in jeopardy.
 
@@ -19,7 +19,7 @@ A simple and dynamic asynchronous Python wrapper for the Ravy API.
 - Not yet available on PyPI
 
 ```bash
-python3 -m pip install git+https://github.com/GoogleGenius/plane
+python3 -m pip install git+https://github.com/GoogolGenius/RavyAPI.py
 ```
 
 ## Usage
@@ -28,12 +28,12 @@ python3 -m pip install git+https://github.com/GoogleGenius/plane
 # Import required packages
 import asyncio
 
-import plane
+import ravyapi
 
 
 async def main() -> None:
-    # Construct a plane client object
-    client = plane.Client("token")  # Replace "token" with your API key
+    # Construct a ravyapi client object
+    client = ravyapi.Client("token")  # Replace "token" with your API key
 
     # Make a simple request to get token information
     token_info = await client.tokens.get_token()
@@ -51,4 +51,4 @@ asyncio.run(main())
 
 Feel free to create pull requests and issues. Just be civil, kind, and respectful.
 
-This is my first library, so if you have any suggestions or questions, please let me know! Reach out via GitHub Issues or Discord `@googlegenius`.
+This is my first library, so if you have any suggestions or questions, please let me know! Reach out via GitHub Issues or Discord `@googolgenius`.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,12 +6,12 @@
 # Import required packages
 import asyncio
 
-import plane
+import ravyapi
 
 
 async def main() -> None:
-    # Construct a plane client object
-    client = plane.Client("token")  # Replace "token" with your API key
+    # Construct a ravyapi client object
+    client = ravyapi.Client("token")  # Replace "token" with your API key
 
     # Make a simple request to get token information
     token_info = await client.tokens.get_token()
@@ -27,21 +27,21 @@ asyncio.run(main())
 
 ## KSoft Tokens
 
-If you have a KSoft token, you can simply pass it to the constructor for the `plane.client.Client`. Please note that KSoft tokens are not compatible with any endpoints other than `ksoft` and `tokens`.
+If you have a KSoft token, you can simply pass it to the constructor for the `ravyapi.client.Client`. Please note that KSoft tokens are not compatible with any endpoints other than `ksoft` and `tokens`.
 
 ## Phisherman Token
 
-You might have noticed there is no available kwarg to set the phisherman.gg token using the `urls` endpoint. This is because you can instead set it directly to the `plane.client.Client` using the `plane.client.Client.set_phisherman_token()` method. This also returns the `plane.client.Client` object so you can chain calls.
+You might have noticed there is no available kwarg to set the phisherman.gg token using the `urls` endpoint. This is because you can instead set it directly to the `ravyapi.client.Client` using the `ravyapi.client.Client.set_phisherman_token()` method. This also returns the `ravyapi.client.Client` object so you can chain calls.
 
 ```python
 # Assume boilerplate is already set up
-client = plane.Client("token").set_phisherman_token("phisherman_token")
+client = ravyapi.Client("token").set_phisherman_token("phisherman_token")
 website_info = await client.urls.get_website("https://example.com")
 ```
 
 ## Permissions
 
-The API wrapper automatically validates your token's permissions upon the first method call. If you attempt to use an API method that you do not have permission to use, the library will raise a `plane.api.errors.AccessException`. This information is currently stored internally, but not publicly accessible. To manually check for permissions, call the `plane.client.Client.tokens.get_token()` method and use the `access` property.
+The API wrapper automatically validates your token's permissions upon the first method call. If you attempt to use an API method that you do not have permission to use, the library will raise a `ravyapi.api.errors.AccessException`. This information is currently stored internally, but not publicly accessible. To manually check for permissions, call the `ravyapi.client.Client.tokens.get_token()` method and use the `access` property.
 
 ```python
 # Assume boilerplate is already set up
@@ -51,13 +51,13 @@ permissions = token_info.access
 
 ## Error Handling
 
-You can catch the defined errors in the `plane.api.errors` module and handle them appropriately.
+You can catch the defined errors in the `ravyapi.api.errors` module and handle them appropriately.
 
 ```python
 # Assume boilerplate is already set up
 try:
     token_info = await client.tokens.get_token()
-except plane.HTTPException as e:  # Generic HTTP error
+except ravyapi.HTTPException as e:  # Generic HTTP error
     if e.status == 429:
         print(f"Encountered {e.status}: we are being ratelimited by Cloudflare!")
     else:
@@ -65,7 +65,7 @@ except plane.HTTPException as e:  # Generic HTTP error
 
 try:
     website_info = await client.urls.get_website("https://example.com")
-except plane.AccessException as e:  # Access denied
+except ravyapi.AccessException as e:  # Access denied
     print(f"This errored as the endpoint route needed {e.required} permission!")
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Plane
+# RavyAPI.py
 
 A simple and dynamic asynchronous Python wrapper for the Ravy API.
 
@@ -15,7 +15,7 @@ A simple and dynamic asynchronous Python wrapper for the Ravy API.
 - Not yet available on PyPI
 
 ```bash
-python3 -m pip install git+https://github.com/GoogleGenius/plane.git
+python3 -m pip install git+https://github.com/GoogolGenius/RavyAPI.py.git
 ```
 
 ## Usage
@@ -24,12 +24,12 @@ python3 -m pip install git+https://github.com/GoogleGenius/plane.git
 # Import required packages
 import asyncio
 
-import plane
+import ravyapi
 
 
 async def main() -> None:
-    # Construct a plane client object
-    client = plane.Client("token")  # Replace "token" with your API key
+    # Construct a ravyapi client object
+    client = ravyapi.Client("token")  # Replace "token" with your API key
 
     # Make a simple request to get token information
     token_info = await client.tokens.get_token()
@@ -47,4 +47,4 @@ asyncio.run(main())
 
 Feel free to create pull requests and issues. Just be civil, kind, and respectful.
 
-This is my first library, so if you have any suggestions or questions, please let me know! Reach out via GitHub Issues or Discord `@googlegenius`.
+This is my first library, so if you have any suggestions or questions, please let me know! Reach out via GitHub Issues or Discord `@googolgenius`.

--- a/docs/reference/api/endpoints/avatars.md
+++ b/docs/reference/api/endpoints/avatars.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.avatars
+::: ravyapi.api.endpoints.avatars

--- a/docs/reference/api/endpoints/guilds.md
+++ b/docs/reference/api/endpoints/guilds.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.guilds
+::: ravyapi.api.endpoints.guilds

--- a/docs/reference/api/endpoints/ksoft.md
+++ b/docs/reference/api/endpoints/ksoft.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.ksoft
+::: ravyapi.api.endpoints.ksoft

--- a/docs/reference/api/endpoints/tokens.md
+++ b/docs/reference/api/endpoints/tokens.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.tokens
+::: ravyapi.api.endpoints.tokens

--- a/docs/reference/api/endpoints/urls.md
+++ b/docs/reference/api/endpoints/urls.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.urls
+::: ravyapi.api.endpoints.urls

--- a/docs/reference/api/endpoints/users.md
+++ b/docs/reference/api/endpoints/users.md
@@ -1,1 +1,1 @@
-::: plane.api.endpoints.users
+::: ravyapi.api.endpoints.users

--- a/docs/reference/api/errors.md
+++ b/docs/reference/api/errors.md
@@ -1,1 +1,1 @@
-::: plane.api.errors
+::: ravyapi.api.errors

--- a/docs/reference/api/models/avatars.md
+++ b/docs/reference/api/models/avatars.md
@@ -1,1 +1,1 @@
-::: plane.api.models.avatars
+::: ravyapi.api.models.avatars

--- a/docs/reference/api/models/generic/ban_entry.md
+++ b/docs/reference/api/models/generic/ban_entry.md
@@ -1,1 +1,1 @@
-::: plane.api.models.generic.ban_entry
+::: ravyapi.api.models.generic.ban_entry

--- a/docs/reference/api/models/generic/trust.md
+++ b/docs/reference/api/models/generic/trust.md
@@ -1,1 +1,1 @@
-::: plane.api.models.generic.trust
+::: ravyapi.api.models.generic.trust

--- a/docs/reference/api/models/guilds.md
+++ b/docs/reference/api/models/guilds.md
@@ -1,1 +1,1 @@
-::: plane.api.models.guilds
+::: ravyapi.api.models.guilds

--- a/docs/reference/api/models/ksoft.md
+++ b/docs/reference/api/models/ksoft.md
@@ -1,1 +1,1 @@
-::: plane.api.models.ksoft
+::: ravyapi.api.models.ksoft

--- a/docs/reference/api/models/tokens.md
+++ b/docs/reference/api/models/tokens.md
@@ -1,1 +1,1 @@
-::: plane.api.models.tokens
+::: ravyapi.api.models.tokens

--- a/docs/reference/api/models/urls.md
+++ b/docs/reference/api/models/urls.md
@@ -1,1 +1,1 @@
-::: plane.api.models.urls
+::: ravyapi.api.models.urls

--- a/docs/reference/api/models/users.md
+++ b/docs/reference/api/models/users.md
@@ -1,1 +1,1 @@
-::: plane.api.models.users
+::: ravyapi.api.models.users

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,1 +1,1 @@
-::: plane.client
+::: ravyapi.client

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,9 @@
-site_name: Plane Docs
+site_name: RavyAPI.py Docs
 
-copyright: Copyright &copy; 2022-Present GoogleGenius
+copyright: Copyright &copy; 2022-Present GoogolGenius
 
-repo_url: https://github.com/GoogleGenius/plane
-repo_name: GoogleGenius/plane
+repo_url: https://github.com/GoogolGenius/ravyapi.py
+repo_name: GoogolGenius/RavyAPI.py
 
 edit_uri: edit/main/docs/
 
@@ -42,7 +42,7 @@ plugins:
             show_signature_annotations: true
             show_source: false
       watch:
-        - plane
+        - ravyapi
 
 markdown_extensions:
   - admonition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,20 +29,20 @@ license = {file = "LICENSE"}
 maintainers = [
   {name = "Erich Nguyen", email = "erich.nguyen@outlook.com"},
 ]
-name = "plane"
+name = "RavyAPI.py"
 readme = "README.md"
 requires-python = ">=3.7"
 version = "0.1.0a"
 
 [project.urls]
-homepage = "https://github.com/GoogleGenius/plane"
-repository = "https://github.com/GoogleGenius/plane"
+homepage = "https://github.com/GoogolGenius/RavyAPI.py"
+repository = "https://github.com/GoogolGenius/RavyAPI.py"
 
 [tool.setuptools]
 license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
-include = ["plane*"]
+include = ["ravyapi*"]
 
 [tool.pyright]
 pythonVersion = "3.7"

--- a/ravyapi/__init__.py
+++ b/ravyapi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,14 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""API models for the Ravy API endpoints."""
+"""A simple and dynamic asynchronous Python wrapper for the Ravy API."""
 
 from __future__ import annotations
 
-from plane.api.models.avatars import *
-from plane.api.models.generic import *
-from plane.api.models.guilds import *
-from plane.api.models.ksoft import *
-from plane.api.models.tokens import *
-from plane.api.models.urls import *
-from plane.api.models.users import *
+from ravyapi._about import *
+from ravyapi.api import *
+from ravyapi.client import *

--- a/ravyapi/_about.py
+++ b/ravyapi/_about.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,11 +28,11 @@ __all__: tuple[str, ...] = (
 
 from typing_extensions import Final
 
-__author__: Final[str] = "GoogleGenius"
-__repository__: Final[str] = "https://github.com/GoogleGenius/plane"
-__copyright__: Final[str] = "Copyright 2022-Present GoogleGenius"
+__author__: Final[str] = "GoogolGenius"
+__repository__: Final[str] = "https://github.com/GoogolGenius/RavyAPI.py"
+__copyright__: Final[str] = "Copyright 2022-Present GoogolGenius"
 __license__: Final[str] = "Apache v2"
 __version__: Final[str] = "0.1.0a"
-__maintainer__: Final[str] = "GoogleGenius"
+__maintainer__: Final[str] = "GoogolGenius"
 __email__: Final[str] = "erich.nguyen@outlook.com"
 __status__: Final[str] = "Development"

--- a/ravyapi/api/__init__.py
+++ b/ravyapi/api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 from __future__ import annotations
 
-from plane.api.errors import *
+from ravyapi.api.errors import *

--- a/ravyapi/api/endpoints/__init__.py
+++ b/ravyapi/api/endpoints/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""API models for generic object data."""
+"""Implementations for the Ravy API endpoints."""
 
 from __future__ import annotations
 
-from plane.api.models.generic.ban_entry import *
-from plane.api.models.generic.trust import *
+from ravyapi.api.endpoints.avatars import *
+from ravyapi.api.endpoints.guilds import *
+from ravyapi.api.endpoints.ksoft import *
+from ravyapi.api.endpoints.tokens import *
+from ravyapi.api.endpoints.urls import *
+from ravyapi.api.endpoints.users import *

--- a/ravyapi/api/endpoints/avatars.py
+++ b/ravyapi/api/endpoints/avatars.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ import urllib.parse
 import aiohttp
 from typing_extensions import Literal
 
-from plane.api.models import CheckAvatarResponse
-from plane.http import HTTPAwareEndpoint
-from plane.utils import with_permission_check
+from ravyapi.api.models import CheckAvatarResponse
+from ravyapi.http import HTTPAwareEndpoint
+from ravyapi.utils import with_permission_check
 
 
 class Avatars(HTTPAwareEndpoint):
@@ -60,8 +60,8 @@ class Avatars(HTTPAwareEndpoint):
         Returns
         -------
         CheckAvatarResponse
-            A model response from `plane.api.endpoints.avatars.Avatars.check_avatar`.
-            Located as `plane.api.models.avatars.CheckAvatarResponse`.
+            A model response from `ravyapi.api.endpoints.avatars.Avatars.check_avatar`.
+            Located as `ravyapi.api.models.avatars.CheckAvatarResponse`.
         """
         if not isinstance(avatar, (str, bytes)):
             raise TypeError('Parameter "avatar" must be of type "str" or "bytes"')

--- a/ravyapi/api/endpoints/guilds.py
+++ b/ravyapi/api/endpoints/guilds.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 __all__: tuple[str, ...] = ("Guilds",)
 
-from plane.api.models import GetGuildResponse
-from plane.http import HTTPAwareEndpoint
-from plane.utils import with_permission_check
+from ravyapi.api.models import GetGuildResponse
+from ravyapi.http import HTTPAwareEndpoint
+from ravyapi.utils import with_permission_check
 
 
 class Guilds(HTTPAwareEndpoint):
@@ -44,8 +44,8 @@ class Guilds(HTTPAwareEndpoint):
         Returns
         -------
         GetGuildResponse
-            A model response from `plane.api.endpoints.guilds.Guilds.get_guild`.
-            Located as `plane.api.models.guilds.GetGuildResponse`.
+            A model response from `ravyapi.api.endpoints.guilds.Guilds.get_guild`.
+            Located as `ravyapi.api.models.guilds.GetGuildResponse`.
         """
         if not isinstance(guild_id, int):
             raise TypeError('Parameter "guild_id" must be of type "int"')

--- a/ravyapi/api/endpoints/ksoft.py
+++ b/ravyapi/api/endpoints/ksoft.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 __all__: tuple[str, ...] = ("KSoft",)
 
-from plane.api.models import GetKSoftBanResponse
-from plane.http import HTTPAwareEndpoint
-from plane.utils import with_permission_check
+from ravyapi.api.models import GetKSoftBanResponse
+from ravyapi.http import HTTPAwareEndpoint
+from ravyapi.utils import with_permission_check
 
 
 class KSoft(HTTPAwareEndpoint):
@@ -44,8 +44,8 @@ class KSoft(HTTPAwareEndpoint):
         Returns
         -------
         GetKSoftBanResponse
-            A model response from `plane.api.endpoints.ksoft.KSoft.get_ban`.
-            Located as `plane.api.models.ksoft.GetKSoftBanResponse`.
+            A model response from `ravyapi.api.endpoints.ksoft.KSoft.get_ban`.
+            Located as `ravyapi.api.models.ksoft.GetKSoftBanResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')

--- a/ravyapi/api/endpoints/tokens.py
+++ b/ravyapi/api/endpoints/tokens.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ from __future__ import annotations
 
 __all__: tuple[str, ...] = ("Tokens",)
 
-from plane.api.models import GetTokenResponse
-from plane.http import HTTPAwareEndpoint
+from ravyapi.api.models import GetTokenResponse
+from ravyapi.http import HTTPAwareEndpoint
 
 
 class Tokens(HTTPAwareEndpoint):
@@ -32,7 +32,7 @@ class Tokens(HTTPAwareEndpoint):
         Returns
         -------
         GetTokenResponse
-            A model response from `plane.api.endpoints.tokens.Tokens.get_token`.
-            Located as `plane.api.models.tokens.GetTokenResponse`.
+            A model response from `ravyapi.api.endpoints.tokens.Tokens.get_token`.
+            Located as `ravyapi.api.models.tokens.GetTokenResponse`.
         """
         return GetTokenResponse(await self._http.get(self._http.paths.tokens.route))

--- a/ravyapi/api/endpoints/urls.py
+++ b/ravyapi/api/endpoints/urls.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,9 +20,9 @@ __all__: tuple[str, ...] = ("URLs",)
 import urllib.parse
 from typing import Any
 
-from plane.api.models import EditWebsiteRequest, GetWebsiteResponse
-from plane.http import HTTPAwareEndpoint
-from plane.utils import with_permission_check
+from ravyapi.api.models import EditWebsiteRequest, GetWebsiteResponse
+from ravyapi.http import HTTPAwareEndpoint
+from ravyapi.utils import with_permission_check
 
 
 class URLs(HTTPAwareEndpoint):
@@ -47,7 +47,7 @@ class URLs(HTTPAwareEndpoint):
         author : int | None
             Optional, the user that posted the message containing this URL (for auto banning, requires admin.users).
         phisherman_user : int | None
-            Optional, required if `plane.client.Client.set_phisherman_token` is called, Discord user ID of the token owner.
+            Optional, required if `ravyapi.client.Client.set_phisherman_token` is called, Discord user ID of the token owner.
 
         Raises
         ------
@@ -59,8 +59,8 @@ class URLs(HTTPAwareEndpoint):
         Returns
         -------
         GetWebsiteResponse
-            A model response from `plane.api.endpoints.urls.URLs.get_website`.
-            Located as `plane.api.models.urls.GetWebsiteResponse`.
+            A model response from `ravyapi.api.endpoints.urls.URLs.get_website`.
+            Located as `ravyapi.api.models.urls.GetWebsiteResponse`.
         """
         if not isinstance(url, str):
             raise TypeError('Parameter "url" must be of type "str"')

--- a/ravyapi/api/endpoints/users.py
+++ b/ravyapi/api/endpoints/users.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 __all__: tuple[str, ...] = ("Users",)
 
-from plane.api.models import (
+from ravyapi.api.models import (
     BanEntryRequest,
     GetBansResponse,
     GetPronounsResponse,
@@ -25,8 +25,8 @@ from plane.api.models import (
     GetUserResponse,
     GetWhitelistsResponse,
 )
-from plane.http import HTTPAwareEndpoint
-from plane.utils import with_permission_check
+from ravyapi.http import HTTPAwareEndpoint
+from ravyapi.utils import with_permission_check
 
 
 class Users(HTTPAwareEndpoint):
@@ -51,8 +51,8 @@ class Users(HTTPAwareEndpoint):
         Returns
         -------
         GetUserResponse
-            A model response from `plane.api.endpoints.users.Users.get_user`.
-            Located as `plane.api.models.users.GetUserResponse`.
+            A model response from `ravyapi.api.endpoints.users.Users.get_user`.
+            Located as `ravyapi.api.models.users.GetUserResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')
@@ -80,8 +80,8 @@ class Users(HTTPAwareEndpoint):
         Returns
         -------
         GetPronounsResponse
-            A model response from `plane.api.endpoints.users.Users.get_pronouns`.
-            Located as `plane.api.models.users.GetPronounsResponse`.
+            A model response from `ravyapi.api.endpoints.users.Users.get_pronouns`.
+            Located as `ravyapi.api.models.users.GetPronounsResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')
@@ -107,8 +107,8 @@ class Users(HTTPAwareEndpoint):
         Returns
         -------
         GetBansResponse
-            A model response from `plane.api.endpoints.users.Users.get_bans`.
-            Located as `plane.api.models.users.GetBansResponse`.
+            A model response from `ravyapi.api.endpoints.users.Users.get_bans`.
+            Located as `ravyapi.api.models.users.GetBansResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')
@@ -197,8 +197,8 @@ class Users(HTTPAwareEndpoint):
         Returns
         -------
         GetWhitelistsResponse
-            A model response from `plane.api.endpoints.users.Users.get_whitelists`.
-            Located as `plane.api.models.users.GetWhitelistsResponse`.
+            A model response from `ravyapi.api.endpoints.users.Users.get_whitelists`.
+            Located as `ravyapi.api.models.users.GetWhitelistsResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')
@@ -226,8 +226,8 @@ class Users(HTTPAwareEndpoint):
         Returns
         -------
         GetReputationResponse
-            A model response from `plane.api.endpoints.users.Users.get_reputation`.
-            Located as `plane.api.models.users.GetReputationResponse`.
+            A model response from `ravyapi.api.endpoints.users.Users.get_reputation`.
+            Located as `ravyapi.api.models.users.GetReputationResponse`.
         """
         if not isinstance(user_id, int):
             raise TypeError('Parameter "user_id" must be of type "int"')

--- a/ravyapi/api/errors.py
+++ b/ravyapi/api/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ravyapi/api/models/__init__.py
+++ b/ravyapi/api/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A simple and dynamic asynchronous Python wrapper for the Ravy API."""
+"""API models for the Ravy API endpoints."""
 
 from __future__ import annotations
 
-from plane._about import *
-from plane.api import *
-from plane.client import *
+from ravyapi.api.models.avatars import *
+from ravyapi.api.models.generic import *
+from ravyapi.api.models.guilds import *
+from ravyapi.api.models.ksoft import *
+from ravyapi.api.models.tokens import *
+from ravyapi.api.models.urls import *
+from ravyapi.api.models.users import *

--- a/ravyapi/api/models/avatars.py
+++ b/ravyapi/api/models/avatars.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ from typing import Any
 
 
 class CheckAvatarResponse:
-    """A model response from `plane.api.endpoints.avatars.Avatars.check_avatar`.
+    """A model response from `ravyapi.api.endpoints.avatars.Avatars.check_avatar`.
 
     Attributes
     ----------

--- a/ravyapi/api/models/generic/__init__.py
+++ b/ravyapi/api/models/generic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,13 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementations for the Ravy API endpoints."""
+"""API models for generic object data."""
 
 from __future__ import annotations
 
-from plane.api.endpoints.avatars import *
-from plane.api.endpoints.guilds import *
-from plane.api.endpoints.ksoft import *
-from plane.api.endpoints.tokens import *
-from plane.api.endpoints.urls import *
-from plane.api.endpoints.users import *
+from ravyapi.api.models.generic.ban_entry import *
+from ravyapi.api.models.generic.trust import *

--- a/ravyapi/api/models/generic/ban_entry.py
+++ b/ravyapi/api/models/generic/ban_entry.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ravyapi/api/models/generic/trust.py
+++ b/ravyapi/api/models/generic/trust.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ravyapi/api/models/guilds.py
+++ b/ravyapi/api/models/guilds.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,20 +19,20 @@ __all__: tuple[str, ...] = ("GetGuildResponse",)
 
 from typing import Any
 
-from plane.api.models.generic import BanEntryResponse, Trust
+from ravyapi.api.models.generic import BanEntryResponse, Trust
 
 
 class GetGuildResponse:
-    """A model response from `plane.api.endpoints.guilds.Guilds.get_guild`.
+    """A model response from `ravyapi.api.endpoints.guilds.Guilds.get_guild`.
 
     Attributes
     ----------
     data: dict[str, Any]
         The raw data returned from the Ravy API.
     trust: Trust
-        The guild's `plane.api.models.generic.trust.Trust` trust model.
+        The guild's `ravyapi.api.models.generic.trust.Trust` trust model.
     bans: list[BanEntryResponse]
-        A list of the guild's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models.
+        A list of the guild's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models.
     """
 
     __slots__: tuple[str, ...] = ("_data", "_trust", "_bans")
@@ -57,10 +57,10 @@ class GetGuildResponse:
 
     @property
     def trust(self) -> Trust:
-        """The guild's `plane.api.models.generic.trust.Trust` trust model."""
+        """The guild's `ravyapi.api.models.generic.trust.Trust` trust model."""
         return self._trust
 
     @property
     def bans(self) -> list[BanEntryResponse]:
-        """A list of the guilds's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models."""
+        """A list of the guilds's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models."""
         return self._bans

--- a/ravyapi/api/models/ksoft.py
+++ b/ravyapi/api/models/ksoft.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ from typing import Any
 
 
 class GetKSoftBanResponse:
-    """A model response from `plane.api.endpoints.ksoft.KSoft.get_ban`.
+    """A model response from `ravyapi.api.endpoints.ksoft.KSoft.get_ban`.
 
     Attributes
     ----------

--- a/ravyapi/api/models/tokens.py
+++ b/ravyapi/api/models/tokens.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ from typing_extensions import Literal
 
 
 class GetTokenResponse:
-    """A model response from `plane.api.endpoints.tokens.Tokens.get_token`.
+    """A model response from `ravyapi.api.endpoints.tokens.Tokens.get_token`.
 
     Attributes
     ----------

--- a/ravyapi/api/models/urls.py
+++ b/ravyapi/api/models/urls.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ from typing import Any
 
 
 class GetWebsiteResponse:
-    """A model response from `plane.api.endpoints.urls.URLs.get_website`.
+    """A model response from `ravyapi.api.endpoints.urls.URLs.get_website`.
 
     Attributes
     ----------
@@ -63,7 +63,7 @@ class GetWebsiteResponse:
 
 
 class EditWebsiteRequest:
-    """A model request to `plane.api.endpoints.urls.URLs.edit_website`.
+    """A model request to `ravyapi.api.endpoints.urls.URLs.edit_website`.
 
     Parameters
     ----------

--- a/ravyapi/api/models/users.py
+++ b/ravyapi/api/models/users.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,11 +28,11 @@ __all__: tuple[str, ...] = (
 
 from typing import Any
 
-from plane.api.models.generic import BanEntryResponse, Trust
+from ravyapi.api.models.generic import BanEntryResponse, Trust
 
 
 class GetUserResponse:
-    """A model response from `plane.api.endpoints.users.Users.get_user`.
+    """A model response from `ravyapi.api.endpoints.users.Users.get_user`.
 
     Attributes
     ----------
@@ -41,15 +41,15 @@ class GetUserResponse:
     pronouns : str
         The user's pronouns.
     trust : Trust
-        The user's `plane.api.models.generic.trust.Trust` trust model.
+        The user's `ravyapi.api.models.generic.trust.Trust` trust model.
     whitelists : list[WhitelistEntry]
-        A list of the user's `plane.api.models.users.WhitelistEntry` whitelist models.
+        A list of the user's `ravyapi.api.models.users.WhitelistEntry` whitelist models.
     bans : list[BanEntryResponse]
-        A list of the user's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models.
+        A list of the user's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models.
     rep : list[ReputationEntry]
-        A list of the user's `plane.api.models.users.ReputationEntry` reputation models.
+        A list of the user's `ravyapi.api.models.users.ReputationEntry` reputation models.
     sentinel : SentinelEntry
-        The user's `plane.api.models.users.SentinelEntry` sentinel model.
+        The user's `ravyapi.api.models.users.SentinelEntry` sentinel model.
     """
 
     __slots__: tuple[str, ...] = (
@@ -95,32 +95,32 @@ class GetUserResponse:
 
     @property
     def trust(self) -> Trust:
-        """The user's `plane.api.models.generic.trust.Trust` trust model."""
+        """The user's `ravyapi.api.models.generic.trust.Trust` trust model."""
         return self._trust
 
     @property
     def whitelists(self) -> list[WhitelistEntry]:
-        """A list of the user's `plane.api.models.users.WhitelistEntry` whitelist models."""
+        """A list of the user's `ravyapi.api.models.users.WhitelistEntry` whitelist models."""
         return self._whitelists
 
     @property
     def bans(self) -> list[BanEntryResponse]:
-        """A list of the user's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models."""
+        """A list of the user's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models."""
         return self._bans
 
     @property
     def rep(self) -> list[ReputationEntry]:
-        """A list of the user's `plane.api.models.users.ReputationEntry` reputation models."""
+        """A list of the user's `ravyapi.api.models.users.ReputationEntry` reputation models."""
         return self._rep
 
     @property
     def sentinel(self) -> SentinelEntry:
-        """The user's `plane.api.models.users.SentinelEntry` sentinel model."""
+        """The user's `ravyapi.api.models.users.SentinelEntry` sentinel model."""
         return self._sentinel
 
 
 class GetPronounsResponse:
-    """A model response from `plane.api.endpoints.users.Users.get_pronouns`.
+    """A model response from `ravyapi.api.endpoints.users.Users.get_pronouns`.
 
     Attributes
     ----------
@@ -154,16 +154,16 @@ class GetPronounsResponse:
 
 
 class GetBansResponse:
-    """A model response from `plane.api.endpoints.users.Users.get_bans`.
+    """A model response from `ravyapi.api.endpoints.users.Users.get_bans`.
 
     Attributes
     ----------
     data : dict[str, Any]
         The raw data returned from the Ravy API.
     trust : Trust
-        The user's `plane.api.models.generic.trust.Trust` trust model.
+        The user's `ravyapi.api.models.generic.trust.Trust` trust model.
     bans : list[BanEntryResponse]
-        A list of the user's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models.
+        A list of the user's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models.
     """
 
     __slots__: tuple[str, ...] = ("_data", "_trust", "_bans")
@@ -186,26 +186,26 @@ class GetBansResponse:
 
     @property
     def trust(self) -> Trust:
-        """The user's `plane.api.models.generic.trust.Trust` trust model."""
+        """The user's `ravyapi.api.models.generic.trust.Trust` trust model."""
         return self._trust
 
     @property
     def bans(self) -> list[BanEntryResponse]:
-        """A list of the user's `plane.api.models.generic.ban_entry.BanEntryResponse` ban models."""
+        """A list of the user's `ravyapi.api.models.generic.ban_entry.BanEntryResponse` ban models."""
         return self._bans
 
 
 class GetWhitelistsResponse:
-    """A model response from `plane.api.endpoints.users.Users.get_whitelists`.
+    """A model response from `ravyapi.api.endpoints.users.Users.get_whitelists`.
 
     Attributes
     ----------
     data : dict[str, Any]
         The raw data returned from the Ravy API.
     whitelists : list[WhitelistEntry]
-        A list of the user's `plane.api.models.users.WhitelistEntry` whitelist models.
+        A list of the user's `ravyapi.api.models.users.WhitelistEntry` whitelist models.
     trust : Trust
-        The user's `plane.api.models.generic.trust.Trust` trust model.
+        The user's `ravyapi.api.models.generic.trust.Trust` trust model.
     """
 
     __slots__: tuple[str, ...] = ("_data", "_whitelists", "_trust")
@@ -230,26 +230,26 @@ class GetWhitelistsResponse:
 
     @property
     def whitelists(self) -> list[WhitelistEntry]:
-        """A list of the user's `plane.api.models.users.WhitelistEntry` whitelist models."""
+        """A list of the user's `ravyapi.api.models.users.WhitelistEntry` whitelist models."""
         return self._whitelists
 
     @property
     def trust(self) -> Trust:
-        """The user's `plane.api.models.generic.trust.Trust` trust model."""
+        """The user's `ravyapi.api.models.generic.trust.Trust` trust model."""
         return self._trust
 
 
 class GetReputationResponse:
-    """A model response from `plane.api.endpoints.users.Users.get_reputation`.
+    """A model response from `ravyapi.api.endpoints.users.Users.get_reputation`.
 
     Attributes
     ----------
     data : dict[str, Any]
         The raw data returned from the Ravy API.
     rep : list[ReputationEntry]
-        A list of the user's `plane.api.models.users.ReputationEntry` reputation models.
+        A list of the user's `ravyapi.api.models.users.ReputationEntry` reputation models.
     trust : Trust
-        The user's `plane.api.models.generic.trust.Trust` trust model.
+        The user's `ravyapi.api.models.generic.trust.Trust` trust model.
     """
 
     __slots__: tuple[str, ...] = ("_data", "_rep", "_trust")
@@ -272,12 +272,12 @@ class GetReputationResponse:
 
     @property
     def rep(self) -> list[ReputationEntry]:
-        """A list of the user's `plane.api.models.users.ReputationEntry` reputation models."""
+        """A list of the user's `ravyapi.api.models.users.ReputationEntry` reputation models."""
         return self._rep
 
     @property
     def trust(self) -> Trust:
-        """The user's `plane.api.models.generic.trust.Trust` trust model."""
+        """The user's `ravyapi.api.models.generic.trust.Trust` trust model."""
         return self._trust
 
 

--- a/ravyapi/api/paths.py
+++ b/ravyapi/api/paths.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ravyapi/client.py
+++ b/ravyapi/client.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ import logging
 
 from typing_extensions import Final
 
-from plane.api.endpoints import Avatars, Guilds, KSoft, Tokens, URLs, Users
-from plane.http import HTTPClient
+from ravyapi.api.endpoints import Avatars, Guilds, KSoft, Tokens, URLs, Users
+from ravyapi.http import HTTPClient
 
-_LOGGER: Final[logging.Logger] = logging.getLogger("plane.client")
+_LOGGER: Final[logging.Logger] = logging.getLogger("ravyapi.client")
 
 
 class Client:

--- a/ravyapi/const.py
+++ b/ravyapi/const.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ import platform
 import aiohttp
 from typing_extensions import Final
 
-from plane._about import __author__, __repository__, __version__
+from ravyapi._about import __author__, __repository__, __version__
 
 BASE_URL: Final[str] = "https://ravy.org/api/v1"
 """The base URL for the Ravy API."""
@@ -61,7 +61,7 @@ KSOFT_TOKEN_REGEX: Final[str] = r"[0-9a-f]{40}"
 
 # Totally not copied from Hikari lol
 USER_AGENT: Final[str] = (
-    f"plane ({__repository__}, {__version__}) {__author__} "
+    f"RavyAPI.py ({__repository__}, {__version__}) {__author__} "
     f"aiohttp/{aiohttp.__version__} "
     f"{platform.python_implementation()}/{platform.python_version()} "
     f"{platform.system()} {platform.architecture()[0]}"

--- a/ravyapi/http.py
+++ b/ravyapi/http.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ from typing import Any
 import aiohttp
 from typing_extensions import Final
 
-from plane.api.errors import (
+from ravyapi.api.errors import (
     BadRequestError,
     ForbiddenError,
     HTTPError,
@@ -32,11 +32,11 @@ from plane.api.errors import (
     TooManyRequestsError,
     UnauthorizedError,
 )
-from plane.api.models import GetTokenResponse
-from plane.api.paths import Paths
-from plane.const import BASE_URL, KSOFT_TOKEN_REGEX, RAVY_TOKEN_REGEX, USER_AGENT
+from ravyapi.api.models import GetTokenResponse
+from ravyapi.api.paths import Paths
+from ravyapi.const import BASE_URL, KSOFT_TOKEN_REGEX, RAVY_TOKEN_REGEX, USER_AGENT
 
-_LOGGER: Final[logging.Logger] = logging.getLogger("plane.http")
+_LOGGER: Final[logging.Logger] = logging.getLogger("ravyapi.http")
 
 
 class HTTPClient:
@@ -200,7 +200,7 @@ class HTTPClient:
 
     @property
     def paths(self) -> Paths:
-        """An instance of `plane.api.paths.Path` for routing."""
+        """An instance of `ravyapi.api.paths.Path` for routing."""
         return Paths()
 
     @property
@@ -220,7 +220,7 @@ class HTTPClient:
 
 
 class HTTPAwareEndpoint:
-    """A class representing an endpoint implementation aware of the underlying `plane.http.HTTPClient`."""
+    """A class representing an endpoint implementation aware of the underlying `ravyapi.http.HTTPClient`."""
 
     __slots__: tuple[str, ...] = ("_http",)
 

--- a/ravyapi/utils.py
+++ b/ravyapi/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ from typing import TYPE_CHECKING, Any, Callable, Coroutine, TypeVar
 
 from typing_extensions import Concatenate, ParamSpec, TypeAlias
 
-from plane.api.errors import AccessError
+from ravyapi.api.errors import AccessError
 
 if TYPE_CHECKING:
-    from plane.http import HTTPAwareEndpoint
+    from ravyapi.http import HTTPAwareEndpoint
 
     _EndpointP = ParamSpec("_EndpointP")
     _EndpointT = TypeVar("_EndpointT")
@@ -67,7 +67,7 @@ def with_permission_check(
     [_EndpointF[_EndpointP, _EndpointT, _EndpointR]],
     _EndpointF[_EndpointP, _EndpointT, _EndpointR],
 ]:
-    """Decorate an instance method of `plane.http.HTTPAwareEndpoint` to validate the required permissions.
+    """Decorate an instance method of `ravyapi.http.HTTPAwareEndpoint` to validate the required permissions.
 
     !!! warning
         This is an internal function and should not be used unless you know what you are doing.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022-Present GoogleGenius
+# Copyright 2022-Present GoogolGenius
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Rename the API wrapper from 'plane' to 'ravyapi' throughout the codebase, including all references in code, documentation, and comments.

Enhancements:
- Rename all instances of 'plane' to 'ravyapi' across the codebase for consistency with the new naming convention.

Documentation:
- Update documentation to reflect the renaming from 'plane' to 'ravyapi', including usage examples and error handling.

<!-- Generated by sourcery-ai[bot]: end summary -->